### PR TITLE
Allow links as close buttons, fix for turbolinks

### DIFF
--- a/animatedModal.js
+++ b/animatedModal.js
@@ -91,10 +91,15 @@
 
 
         closeBt.click(function(event) {
-            event.preventDefault();
+         
             $('body, html').css({'overflow':'auto'});
+            
+            if (this.href) return true;
+            
+            event.preventDefault();
 
             settings.beforeClose(); //beforeClose
+            
             if (id.hasClass(settings.modalTarget+'-on')) {
                 id.removeClass(settings.modalTarget+'-on');
                 id.addClass(settings.modalTarget+'-off');


### PR DESCRIPTION
this will allow links to behave as close buttons.
setting the body and html to overflow:hidden will prevent subsequent pages from scrolling when using turbolinks.
